### PR TITLE
Increase priority of response listener so it runs before profiler

### DIFF
--- a/src/EventListener/RequestIdListener.php
+++ b/src/EventListener/RequestIdListener.php
@@ -79,7 +79,7 @@ final class RequestIdListener implements EventSubscriberInterface
     {
         return [
             KernelEvents::REQUEST   => ['onRequest', 100],
-            KernelEvents::RESPONSE  => ['onResponse', -100],
+            KernelEvents::RESPONSE  => ['onResponse', -99],
         ];
     }
 


### PR DESCRIPTION
If it runs after the profiler, you won't see the added header in the
profiler output.