### PR TITLE
Update Twig classes to use new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ monolog:
 
 ## Twig Integration
 
+**Important**: Twig ^1.38 or ^2.7 is required for the twig integration to work.
+
 By default this bundle will add a global `request_id` function to your twig
 environment. To disable this set `enable_twig` to `false` in the bundle
 configuration.

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require-dev": {
         "phpunit/phpunit": "~7.5",
         "symfony/monolog-bundle": "~3.0",
+        "twig/twig": "^1.38|^2.7",
         "symfony/twig-bundle": "~3.4|~4.0",
         "symfony/browser-kit": "~3.4|~4.0",
         "symfony/css-selector": "~3.4|~4.0",

--- a/src/DependencyInjection/ChrisguitarguyRequestIdExtension.php
+++ b/src/DependencyInjection/ChrisguitarguyRequestIdExtension.php
@@ -66,7 +66,7 @@ final class ChrisguitarguyRequestIdExtension extends ConfigurableExtension
                 ->addTag('monolog.processor');
         }
 
-        if (class_exists('Twig_Extension') && !empty($config['enable_twig'])) {
+        if (class_exists('Twig\Extension\AbstractExtension') && !empty($config['enable_twig'])) {
             $container->register(RequestIdExtension::class)
                 ->addArgument(new Reference($storeId))
                 ->setPublic(false)

--- a/src/Twig/RequestIdExtension.php
+++ b/src/Twig/RequestIdExtension.php
@@ -14,13 +14,15 @@
 namespace Chrisguitarguy\RequestId\Twig;
 
 use Chrisguitarguy\RequestId\RequestIdStorage;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Add the request ID to twig as a function.
  *
  * @since   1.0
  */
-final class RequestIdExtension extends \Twig_Extension
+final class RequestIdExtension extends AbstractExtension
 {
     /**
      * @var RequestIdStorage
@@ -38,7 +40,7 @@ final class RequestIdExtension extends \Twig_Extension
     public function getFunctions() : array
     {
         return [
-            new \Twig_SimpleFunction('request_id', [$this->idStorage, 'getRequestId']),
+            new TwigFunction('request_id', [$this->idStorage, 'getRequestId']),
         ];
     }
 

--- a/test/acceptance/app/config/config.yml
+++ b/test/acceptance/app/config/config.yml
@@ -8,8 +8,6 @@ framework:
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: "%kernel.debug%"
-    templating:
-        engines: ['twig']
     default_locale:  "%locale%"
 
 twig:

--- a/test/unit/Twig/RequestIdExtensionTest.php
+++ b/test/unit/Twig/RequestIdExtensionTest.php
@@ -13,6 +13,8 @@
 namespace Chrisguitarguy\RequestId\Twig;
 
 use Chrisguitarguy\RequestId\SimpleIdStorage;
+use Twig\Loader\ArrayLoader;
+use Twig\Environment;
 
 class RequestIdExtensionTest extends \Chrisguitarguy\RequestId\UnitTestCase
 {
@@ -31,10 +33,10 @@ class RequestIdExtensionTest extends \Chrisguitarguy\RequestId\UnitTestCase
 
     public function setUp()
     {
-        $loader = new \Twig_Loader_Array([
+        $loader = new ArrayLoader([
             'test' => self::TEMPLATE,
         ]);
-        $this->env = new \Twig_Environment($loader);
+        $this->env = new Environment($loader);
         $this->storage = new SimpleIdStorage();
         $this->env->addExtension(new RequestIdExtension($this->storage));
     }


### PR DESCRIPTION
twig_{class} format is deprecated since twig 2.7