### PR TITLE
Symfony 5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - '7.2'
-  - '7.3'
+    - '7.2'
+    - '7.3'
 
 env:
     matrix:

--- a/composer.json
+++ b/composer.json
@@ -6,20 +6,20 @@
     "type": "symfony-bundle",
     "require": {
         "php": "~7.2",
-        "symfony/framework-bundle": "~3.4|~4.0",
+        "symfony/framework-bundle": "^4.4|^5.0",
         "ramsey/uuid": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5",
-        "symfony/monolog-bundle": "~3.0",
-        "twig/twig": "^1.38|^2.7",
-        "symfony/twig-bundle": "~3.4|~4.0",
-        "symfony/browser-kit": "~3.4|~4.0",
-        "symfony/css-selector": "~3.4|~4.0",
-        "symfony/phpunit-bridge": "~3.4|~4.0",
-        "symfony/yaml": "~3.4|~4.0",
-        "symfony/templating": "~3.4|~4.0",
-        "symfony/monolog-bridge": "~3.4|~4.0"
+        "symfony/monolog-bundle": "^3.3.1",
+        "twig/twig": "^2.7|^3.0",
+        "symfony/twig-bundle": "^4.4|^5.0",
+        "symfony/browser-kit": "^4.4|^5.0",
+        "symfony/css-selector": "^4.4|^5.0",
+        "symfony/phpunit-bridge": "^4.4|^5.0",
+        "symfony/yaml": "^4.4|^5.0",
+        "symfony/templating": "^4.4|^5.0",
+        "symfony/monolog-bridge": "^4.4|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,10 @@
          stopOnFailure="false"
          bootstrap="test/bootstrap.php">
 
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+    </php>
+
     <testsuites>
         <testsuite name="integration">
             <directory suffix="Test.php">test/acceptance/</directory>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,16 +23,9 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder() : TreeBuilder
     {
-        // compat: symfony < 4.1
-        if (method_exists(TreeBuilder::class, 'getRootNode')) {
-            $tree = new TreeBuilder('chrisguitarguy_request_id');
-            $root = $tree->getRootNode();
-        } else {
-            $tree = new TreeBuilder();
-            $root = $tree->root('chrisguitarguy_request_id');
-        }
+        $tree = new TreeBuilder('chrisguitarguy_request_id');
 
-        $root
+        $tree->getRootNode()
             ->children()
             ->scalarNode('request_header')
                 ->cannotBeEmpty()

--- a/src/EventListener/RequestIdListener.php
+++ b/src/EventListener/RequestIdListener.php
@@ -14,9 +14,9 @@
 namespace Chrisguitarguy\RequestId\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Chrisguitarguy\RequestId\RequestIdGenerator;
 use Chrisguitarguy\RequestId\RequestIdStorage;
 
@@ -83,7 +83,7 @@ final class RequestIdListener implements EventSubscriberInterface
         ];
     }
 
-    public function onRequest(GetResponseEvent $event) : void
+    public function onRequest(RequestEvent $event) : void
     {
         if (!$event->isMasterRequest()) {
             return;
@@ -110,7 +110,7 @@ final class RequestIdListener implements EventSubscriberInterface
         $this->idStorage->setRequestId($id);
     }
 
-    public function onResponse(FilterResponseEvent $event) : void
+    public function onResponse(ResponseEvent $event) : void
     {
         if (!$event->isMasterRequest()) {
             return;

--- a/src/Twig/RequestIdExtension.php
+++ b/src/Twig/RequestIdExtension.php
@@ -43,12 +43,4 @@ final class RequestIdExtension extends AbstractExtension
             new TwigFunction('request_id', [$this->idStorage, 'getRequestId']),
         ];
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName() : string
-    {
-        return 'chirsguitarguy_request_id';
-    }
 }

--- a/test/acceptance/MemoryHandler.php
+++ b/test/acceptance/MemoryHandler.php
@@ -22,7 +22,7 @@ final class MemoryHandler extends AbstractProcessingHandler implements \Countabl
     /**
      * {@inheritdoc}
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $this->logs[] = (string) $record['formatted'];
     }

--- a/test/acceptance/app/TestKernel.php
+++ b/test/acceptance/app/TestKernel.php
@@ -23,7 +23,7 @@ final class TestKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load($this->getRootDir()."/config/config.yml");
+        $loader->load($this->getProjectDir()."/config/config.yml");
     }
 
     public function getLogDir()
@@ -36,7 +36,7 @@ final class TestKernel extends Kernel
         return __DIR__.'/tmp';
     }
 
-    public function getRootDir()
+    public function getProjectDir()
     {
         return __DIR__;
     }

--- a/test/acceptance/app/config/config.yml
+++ b/test/acceptance/app/config/config.yml
@@ -6,14 +6,14 @@ framework:
     test: ~
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/config/routing.yml"
         strict_requirements: "%kernel.debug%"
     default_locale:  "%locale%"
 
 twig:
   strict_variables: "%kernel.debug%"
   paths:
-    "%kernel.root_dir%/templates": requestid
+    "%kernel.project_dir%/templates": requestid
 
 services:
     log.formatter:


### PR DESCRIPTION
I had to remove Symfony 3.4 compatibility as the HttpKernel Event classes has been renamed.