### PR TITLE
fix deprecated for php8.1 + upgrade to symfony 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,20 +6,20 @@
     "type": "symfony-bundle",
     "require": {
         "php": "^7.4 || ^8.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
         "ramsey/uuid": "^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",
         "symfony/monolog-bundle": "^3.3.1",
         "twig/twig": "^2.7 || ^3.0",
-        "symfony/twig-bundle": "^4.4 || ^5.0",
-        "symfony/browser-kit": "^4.4 || ^5.0",
-        "symfony/css-selector": "^4.4 || ^5.0",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0",
-        "symfony/yaml": "^4.4 || ^5.0",
-        "symfony/templating": "^4.4 || ^5.0",
-        "symfony/monolog-bridge": "^4.4 || ^5.0"
+        "symfony/twig-bundle": "^4.4 || ^5.0 || ^6.0",
+        "symfony/browser-kit": "^4.4 || ^5.0 || ^6.0",
+        "symfony/css-selector": "^4.4 || ^5.0 || ^6.0",
+        "symfony/phpunit-bridge": "^4.4 || ^5.0 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.0 || ^6.0",
+        "symfony/templating": "^4.4 || ^5.0 || ^6.0",
+        "symfony/monolog-bridge": "^4.4 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/test/acceptance/AcceptanceTest.php
+++ b/test/acceptance/AcceptanceTest.php
@@ -98,7 +98,7 @@ class HttpTest extends WebTestCase
         $this->assertInstanceOf($class, $service);
     }
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         return TestKernel::class;
     }

--- a/test/acceptance/MemoryHandler.php
+++ b/test/acceptance/MemoryHandler.php
@@ -27,9 +27,9 @@ final class MemoryHandler extends AbstractProcessingHandler implements \Countabl
         $this->logs[] = (string) $record['formatted'];
     }
 
-    public function count()
+    public function count(): int
     {
-        return count($this->logs);
+        return \count($this->logs);
     }
 
     public function getLogs()

--- a/test/acceptance/app/TestKernel.php
+++ b/test/acceptance/app/TestKernel.php
@@ -9,7 +9,7 @@ final class TestKernel extends Kernel
 {
     private $configFile;
 
-    public function registerBundles()
+    public function registerBundles(): array
     {
         $bundles = array(
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
@@ -26,17 +26,17 @@ final class TestKernel extends Kernel
         $loader->load($this->getProjectDir()."/config/config.yml");
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return __DIR__.'/tmp';
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return __DIR__.'/tmp';
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }
@@ -46,7 +46,7 @@ final class TestKernel extends Kernel
         return $this->getContainer()->get('log.memory_handler')->getLogs();
     }
 
-    public function boot()
+    public function boot(): void
     {
         // clear up the cached files
         foreach (glob(__DIR__.'/app/tmp/*') as $fn) {

--- a/test/acceptance/app/config/config.yml
+++ b/test/acceptance/app/config/config.yml
@@ -8,6 +8,7 @@ framework:
     router:
         resource: "%kernel.project_dir%/config/routing.yml"
         strict_requirements: "%kernel.debug%"
+        utf8: true
     default_locale:  "%locale%"
 
 twig:


### PR DESCRIPTION
in composer:
- adding php8.1 compatibility
- adding symfony 6.0 compatibility

fix in code:
- adding return typehint (as requested by sf6 + php8.1)
- in test sf config: setting utf8: true (as it will be set to true anyway by sf6