### PR TITLE
Add support for Monolog3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,12 @@ jobs:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
-      
+
       - name: "Install dependencies with composer"
         env:
           SYMFONY_REQUIRE: "${{ matrix.symfony-require }}"
         run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
           composer global require --no-progress --no-scripts --no-plugins symfony/flex
           composer update --no-interaction --no-progress ${{ matrix.composer-flags }}
       - name: "Run PHPUnit"

--- a/src/Monolog/RequestIdProcessor.php
+++ b/src/Monolog/RequestIdProcessor.php
@@ -14,6 +14,7 @@
 namespace Chrisguitarguy\RequestId\Monolog;
 
 use Chrisguitarguy\RequestId\RequestIdStorage;
+use Monolog\LogRecord;
 
 /**
  * Adds the request ID to the Monolog record's `extra` key so it can be used
@@ -33,10 +34,19 @@ final class RequestIdProcessor
         $this->idStorage = $storage;
     }
 
-    public function __invoke(array $record) : array
+    /**
+     * @param array|LogRecord $record
+     *
+     * @return array|LogRecord
+     */
+    public function __invoke($record)
     {
         if ($id = $this->idStorage->getRequestId()) {
-            $record['extra']['request_id'] = $id;
+            if ($record instanceof LogRecord) {
+                $record->extra['request_id'] = $id;
+            } else {
+                $record['extra']['request_id'] = $id;
+            }
         }
 
         return $record;

--- a/test/acceptance/MemoryHandler.php
+++ b/test/acceptance/MemoryHandler.php
@@ -12,6 +12,7 @@
 
 namespace Chrisguitarguy\RequestId;
 
+use Monolog\LogRecord;
 use function count;
 use Countable;
 use Monolog\Handler\AbstractProcessingHandler;
@@ -23,9 +24,13 @@ final class MemoryHandler extends AbstractProcessingHandler implements Countable
     /**
      * {@inheritdoc}
      */
-    protected function write(array $record): void
+    protected function write($record): void
     {
-        $this->logs[] = (string) $record['formatted'];
+        if ($record instanceof LogRecord) {
+            $this->logs[] = (string) $record->formatted;
+        } else {
+            $this->logs[] = (string) $record['formatted'];
+        }
     }
 
     public function count() : int

--- a/test/unit/Monolog/RequestIdProcessorTest.php
+++ b/test/unit/Monolog/RequestIdProcessorTest.php
@@ -14,6 +14,9 @@ namespace Chrisguitarguy\RequestId\Monolog;
 
 use Chrisguitarguy\RequestId\RequestIdStorage;
 use Chrisguitarguy\RequestId\UnitTestCase;
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\LogRecord;
 
 class RequestIdProcessorTest extends UnitTestCase
 {
@@ -21,6 +24,10 @@ class RequestIdProcessorTest extends UnitTestCase
 
     public function testProcessorDoesNotSetRequestIdWhenNoIdIsPresent()
     {
+        if (version_compare(Logger::API, '3', 'ge')) {
+            self::markTestSkipped('The version 1 or 2 of Monolog is required to run this test.');
+        }
+
         $this->withRequestId(null);
 
         $record = call_user_func($this->processor, ['extra' => []]);
@@ -30,12 +37,47 @@ class RequestIdProcessorTest extends UnitTestCase
 
     public function testProcessorAddsRequestIdWhenIdIsPresent()
     {
+        if (version_compare(Logger::API, '3', 'ge')) {
+            self::markTestSkipped('The version 1 or 2 of Monolog is required to run this test.');
+        }
+
         $this->withRequestId('abc123');
 
         $record = call_user_func($this->processor, ['extra' => []]);
 
         $this->assertArrayHasKey('request_id', $record['extra']);
         $this->assertEquals('abc123', $record['extra']['request_id']);
+    }
+
+    public function testProcessorDoesNotSetRequestIdWhenNoIdIsPresentWithMonologAtLeast3()
+    {
+        if (version_compare(Logger::API, '3', 'lt')) {
+            self::markTestSkipped('The Monolog at least 3 is required to run this test.');
+        }
+
+        $this->withRequestId(null);
+        $record = call_user_func(
+            $this->processor,
+            new LogRecord(new \DateTimeImmutable('now'), 'channel', Level::Info, 'foo')
+        );
+
+        $this->assertArrayNotHasKey('request_id', $record->extra);
+    }
+
+    public function testProcessorAddsRequestIdWhenIdIsPresentWithMonologAtLeast3()
+    {
+        if (version_compare(Logger::API, '3', 'lt')) {
+            self::markTestSkipped('The Monolog at least 3 is required to run this test.');
+        }
+
+        $this->withRequestId('abc123');
+        $record = call_user_func(
+            $this->processor,
+            new LogRecord(new \DateTimeImmutable('now'), 'channel', Level::Info, 'foo')
+        );
+
+        $this->assertArrayHasKey('request_id', $record->extra);
+        $this->assertEquals('abc123', $record->extra['request_id']);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
This PR closes issue #26.

Monolog3 made some changes in API.

> Log records have been converted from an array to a Monolog\LogRecord object with public (and mostly readonly) properties. e.g. instead of doing $record['context'] use $record->context. In formatters or handlers if you rather need an array to work with you can use $record->toArray() to get back a Monolog 1/2 style record array. This will contain the enum values instead of enum cases in the level and level_name keys to be more backwards compatible and use simpler data types.

This PR fix error:
```
Chrisguitarguy\RequestId\Monolog\RequestIdProcessor::__invoke(): Argument #1 ($record) must be of type array, Monolog\LogRecord given, called in /app/vendor/monolog/monolog/src/Monolog/Logger.php on line 331
```

Monolog3 requires PHP 8.1.

You can use my demo - https://github.com/morawskim/RequestIdBundle-test
Or use instruction from issue #26.


Fetch a git repository `git clone https://github.com/morawskim/RequestIdBundle-test.git`
Call `docker-compose up -d`
Install dependencies - `docker-compose exec php composer install`

Open web browser and go to `localhost:8080`
You should see a error message:
```
Chrisguitarguy\RequestId\Monolog\RequestIdProcessor::__invoke(): Argument #1 ($record) must be of type array, Monolog\LogRecord given, called in /app/vendor/monolog/monolog/src/Monolog/Logger.php on line 331
```

Switch branch to `fork`.
Install dependencies - `docker-compose exec php composer install`
Refresh webpage. You should see a default Symfony application homepage.
