### PR TITLE
Update readme to reflect Symfony 5/6 configuration syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ class AppKernel extends Kernel
 
 ## Configuration
 
+### Yaml config
 ```yaml
-# in app/config/config.yml
+# in config/packages/chrisguitarguy_request_id.yaml
 
 chrisguitarguy_request_id:
     # The header which the bundle inspects for the incoming request ID
@@ -72,6 +73,47 @@ chrisguitarguy_request_id:
 
     # Whether or not to add the twig extension (see below), defaults to true
     enable_twig: true
+```
+ 
+### PHP config
+```php
+# in config/packages/chrisguitarguy_request_id.php
+<?php
+
+declare(strict_types=1);
+
+use Chrisguitarguy\RequestId\Generator\RamseyUuid4Generator;
+use Chrisguitarguy\RequestId\SimpleIdStorage;
+use Symfony\Config\ChrisguitarguyRequestIdConfig;
+
+return static function (ChrisguitarguyRequestIdConfig $config): void {
+    // The header which the bundle inspects for the incoming request ID
+    // if this is not set an ID will be generated and set at this header
+    $config->requestHeader('Request-Id');
+
+    // Whether or not to trust the incoming request header. This is turned
+    // on by default. If true a value in the `Request-Id` header in the request
+    // will be used as the request ID for the rest of the request. If false
+    // those values are ignored.
+    $config->trustRequestHeader(true);
+
+    // The header which the bundle will set the request ID to on the response
+    $config->responseHeader('Request-Id');
+
+    // The service key of an object that implements
+    // Chrisguitarguy\RequestId\RequestIdStorage
+    $config->storageService(SimpleIdStorage::class);
+
+    # The service key of an object that implements
+    # Chrisguitarguy\RequestId\RequestIdGenerator
+    $config->generatorService(RamseyUuid4Generator::class);
+
+    // Whether or not to add the monolog process (see below), defaults to true
+    $config->enableMonolog(true);
+
+    # Whether or not to add the twig extension (see below), defaults to true
+    $config->enableTwig(true);
+};
 ```
 
 ## How it Works


### PR DESCRIPTION
Nice bundle. The readme however is a slightly outdated and seems to be still focused on an older Symfony project format.

I've updated the `.yaml` configuration example to specify that the config should be under `config/packages/chrisguitarguy_request_id.yaml`

Additionaly, since Symfony 5.3, there are generated config builder classes, which work brilliantly in IDEs. I've added to `.php` config format below the `.yaml` format as an easy copy/pastable example.