### PR TITLE
Make ramsey/uuid library optional, and add symfony/uid as optional UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Use [Composer](https://getcomposer.org/).
 ```
 composer require chrisguitarguy/request-id-bundle
 ```
+And one of the UUIDv4 generator libraries: 
+```
+composer require ramsey/uuid
+```
+```
+composer require symfony/uid
+```
+
 
 Then enable the bundle in your `AppKernel`.
 
@@ -64,7 +72,7 @@ chrisguitarguy_request_id:
 
     # The service key of an object that implements
     # Chrisguitarguy\RequestId\RequestIdGenerator
-    # optional, defaults to a UUID v4 based generator
+    # optional, defaults to a Ramsey's UUID v4 based generator
     generator_service: ~
 
     # Whether or not to add the monolog process (see below), defaults to true

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "type": "symfony-bundle",
     "require": {
         "php": "^7.4 || ^8.0",
-        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
-        "ramsey/uuid": "^3.9 || ^4.3"
+        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
+        "ramsey/uuid": "^3.9 || ^4.3",
         "symfony/monolog-bundle": "^3.7",
         "twig/twig": "^2.7 || ^3.0",
         "symfony/twig-bundle": "^4.4 || ^5.4 || ^6.0",
@@ -19,12 +19,17 @@
         "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^4.4 || ^5.4 || ^6.0",
         "symfony/templating": "^4.4 || ^5.4 || ^6.0",
-        "symfony/monolog-bridge": "^4.4 || ^5.4 || ^6.0"
+        "symfony/monolog-bridge": "^4.4 || ^5.4 || ^6.0",
+        "symfony/uid": "^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {
             "Chrisguitarguy\\RequestId\\": "src/"
         }
+    },
+    "suggest": {
+        "ramsey/uuid": "Ramsey's UUID generator",
+        "symfony/uid": "Symfony's UUID generator"
     },
     "conflict": {
         "twig/twig": "<2.7"

--- a/src/Generator/SymfonyUuid4Generator.php
+++ b/src/Generator/SymfonyUuid4Generator.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of chrisguitarguy/request-id-bundle
+
+ * Copyright (c) Christopher Davis <http://christopherdavis.me>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Chrisguitarguy\RequestId\Generator;
+
+use Chrisguitarguy\RequestId\RequestIdGenerator;
+use Symfony\Component\Uid\Factory\UuidFactory;
+use Symfony\Component\Uid\UuidV4;
+
+/**
+ * Uses symfony/uid to generate a UUIDv4 request ID.
+ */
+final class SymfonyUuid4Generator implements RequestIdGenerator
+{
+    /**
+     * @var UuidFactory
+     */
+    private $factory;
+
+    public function __construct(UuidFactory $factory = null)
+    {
+        $this->factory = $factory ?: new UuidFactory(UuidV4::class, UuidV4::class, UuidV4::class, UuidV4::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(): string
+    {
+        return (string)$this->factory->create();
+    }
+}

--- a/test/unit/Generator/SymfonyUuid4GeneratorTest.php
+++ b/test/unit/Generator/SymfonyUuid4GeneratorTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * This file is part of chrisguitarguy/request-id-bundle
+
+ * Copyright (c) Christopher Davis <http://christopherdavis.me>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/MIT MIT
+ */
+
+namespace Chrisguitarguy\RequestId\Generator;
+
+use Chrisguitarguy\RequestId\UnitTestCase;
+use Symfony\Component\Uid\Factory\UuidFactory;
+
+class SymfonyUuid4GeneratorTest extends UnitTestCase
+{
+    public function testGenerateReturnsANewStringIdentifier(): void
+    {
+        if (!class_exists(UuidFactory::class)) {
+            $this->markTestSkipped(sprintf('%s requires the %s class', __METHOD__, UuidFactory::class));
+
+            return;
+        }
+
+        // we're not going to mock anything here, I'm more
+        // interested in making sure we're using the library
+        // correctly than worry about mocking method calls.
+        $s = new SymfonyUuid4Generator();
+
+        $id = $s->generate();
+
+        $this->assertNotEmpty($id);
+        $this->assertIsString($id);
+    }
+}


### PR DESCRIPTION
In the current form if you choose for a different UUID library, for example `symfony/uid`, Ramsey's uuid library will still be installed on your system. 

Changed:
- moved ramsey/uuid to suggest
- added symfony/uid to suggest
- Added `SymfonyUuid4Generator` class to easily switch to the Symfony uid library.