### PR TITLE
Update to symfony 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,26 +21,16 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          # Symfony 6.X does not support PHP 7.4
-          - php-version: 7.4
-            symfony-require: "4.4.*"
-          - php-version: 7.4
-            symfony-require: "5.4.*"
-
-
-          - php-version: 8.0
-            symfony-require: "4.4.*"
-          - php-version: 8.0
-            symfony-require: "5.4.*"
-
-          - php-version: 8.1
-            symfony-require: "4.4.*"
-          - php-version: 8.1
-            symfony-require: "5.4.*"
-          - php-version: 8.1
-            symfony-require: "6.*"
-
+        php-version:
+          - '8.2'
+          - '8.3'
+        symfony-require:
+          - '5.4.*'
+          - '6.*'
+          - '7.*'
+        composer-flags:
+          - ''
+          - '--prefer-lowest'
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "type": "symfony-bundle",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.2",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
         "ramsey/uuid": "^3.9 || ^4.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,20 +6,20 @@
     "type": "symfony-bundle",
     "require": {
         "php": "^7.4 || ^8.0",
-        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
         "ramsey/uuid": "^3.9 || ^4.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "symfony/monolog-bundle": "^3.7",
         "twig/twig": "^2.7 || ^3.0",
-        "symfony/twig-bundle": "^4.4 || ^5.4 || ^6.0",
-        "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
-        "symfony/css-selector": "^4.4 || ^5.4 || ^6.0",
-        "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.0",
-        "symfony/yaml": "^4.4 || ^5.4 || ^6.0",
-        "symfony/templating": "^4.4 || ^5.4 || ^6.0",
-        "symfony/monolog-bridge": "^4.4 || ^5.4 || ^6.0"
+        "symfony/twig-bundle": "^5.4 || ^6.0 || ^7.0",
+        "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
+        "symfony/css-selector": "^5.4 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
+        "symfony/templating": "^5.4 || ^6.0 || ^7.0",
+        "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/test/unit/EventListener/RequestIdListenerTest.php
+++ b/test/unit/EventListener/RequestIdListenerTest.php
@@ -15,7 +15,6 @@ namespace Chrisguitarguy\RequestId\EventListener;
 use Chrisguitarguy\RequestId\RequestIdGenerator;
 use Chrisguitarguy\RequestId\RequestIdStorage;
 use Chrisguitarguy\RequestId\UnitTestCase;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -56,7 +55,7 @@ class RequestIdListenerTest extends UnitTestCase
         $event = new RequestEvent(
             $this->kernel,
             $this->request,
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
 
         $this->dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -73,7 +72,7 @@ class RequestIdListenerTest extends UnitTestCase
         $event = new RequestEvent(
             $this->kernel,
             $this->request,
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
 
         $this->dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -95,7 +94,7 @@ class RequestIdListenerTest extends UnitTestCase
         $event = new RequestEvent(
             $this->kernel,
             $this->request,
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
 
         $this->dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -128,7 +127,7 @@ class RequestIdListenerTest extends UnitTestCase
         $event = new RequestEvent(
             $this->kernel,
             $this->request,
-            HttpKernelInterface::MASTER_REQUEST
+            HttpKernelInterface::MAIN_REQUEST
         );
 
         $this->dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -164,7 +163,7 @@ class RequestIdListenerTest extends UnitTestCase
             new ResponseEvent(
                 $this->kernel,
                 $this->request,
-                HttpKernelInterface::MASTER_REQUEST,
+                HttpKernelInterface::MAIN_REQUEST,
                 $this->response
             ),
             KernelEvents::RESPONSE
@@ -183,7 +182,7 @@ class RequestIdListenerTest extends UnitTestCase
             new ResponseEvent(
                 $this->kernel,
                 $this->request,
-                HttpKernelInterface::MASTER_REQUEST,
+                HttpKernelInterface::MAIN_REQUEST,
                 $this->response
             ),
             KernelEvents::RESPONSE


### PR DESCRIPTION
Removed version 4.4 since it isn't aware of the main request constant.
It's also EOL. 