### PR TITLE
PHP 8.4 implicitly nullable deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         php-version:
           - '8.2'
           - '8.3'
+          - '8.4'
         symfony-require:
           - '5.4.*'
           - '6.*'

--- a/src/Generator/RamseyUuid4Generator.php
+++ b/src/Generator/RamseyUuid4Generator.php
@@ -29,7 +29,7 @@ final class RamseyUuid4Generator implements RequestIdGenerator
      */
     private $factory;
 
-    public function __construct(UuidFactoryInterface $factory=null)
+    public function __construct(?UuidFactoryInterface $factory=null)
     {
         $this->factory = $factory ?: new UuidFactory();
     }


### PR DESCRIPTION
This fixes the following deprecation warning in PHP 8.4


```
deprecation.INFO: Deprecated: Chrisguitarguy\RequestId\Generator\RamseyUuid4Generator::__construct(): Implicitly marking parameter $factory as nullable is deprecated, the explicit nullable type must be used instead
``` 